### PR TITLE
feat: macOS support + TUI picker → develop

### DIFF
--- a/sentu_install.py
+++ b/sentu_install.py
@@ -708,6 +708,10 @@ def show_menu() -> str:
 
 
 def main():
+    # Redirigir stdin desde /dev/tty si estamos en un pipe (ej: curl | python3)
+    # para que input() y questionary funcionen correctamente.
+    redirect_tty()
+
     show()
     os_name = platform.system()
     logging.info(f"Sistema operativo detectado: {os_name}")


### PR DESCRIPTION
## Cambios incluidos

- ✅ macOS support (Apple Silicon) con Homebrew
- ✅ TUI Application Picker con Questionary (español)
- ✅ Menú interactivo con 5 opciones ([2] solo dotfiles)
- ✅ Cross-platform `.zshrc`
- ✅ Python 3.9 compatible
- ✅ Tart testing infrastructure
- ✅ Apps nuevas: ghostty, opencode

## Fixes aplicados
- Python 3.9: `match/case` → `if/elif`
- Python 3.9: `X | None` → `Optional[X]`
- TTY redirect para `curl | python3`
- `.zshrc.secrets` en `.gitignore`

## Post-merge
- [ ] Ejecutar tests en VMs
- [ ] Verificar regresiones modos [1]-[3]